### PR TITLE
Rollback tinyscript version to 1.24.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 peewee
 prompt_toolkit
 requests
-tinyscript>=1.24.10
+tinyscript==1.24.10


### PR DESCRIPTION
This little change will fix #28, as sploitkit works with older version of tinyscript properly.