### PR TITLE
fix module import for inspect.getargspec()

### DIFF
--- a/sploitkit/core/components/validator.py
+++ b/sploitkit/core/components/validator.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 import shlex
-from inspect import getargspec
+from inspect import getfullargspec
 from prompt_toolkit.validation import Validator, ValidationError
 
 


### PR DESCRIPTION
inspect.getargspec(func) is deprecrated since 3.0 - use getfullargspec() instead. 

Ref: https://docs.python.org/3.9/library/inspect.html#classes-and-functions